### PR TITLE
When using the npm package, the relative folders are not working.

### DIFF
--- a/lib/formful.js
+++ b/lib/formful.js
@@ -9,7 +9,7 @@ var formful = exports,
 formful.name = 'formful';
 
 
-var view = formful.view = new viewful.View({path: './lib/formful/view', input: "html"});
+var view = formful.view = new viewful.View({path: __dirname + '/formful/view', input: "html"});
 
 //
 // Remark: Synchronously load the view


### PR DESCRIPTION
Here is the error I was getting before this pull request....

```
{ [Error: Cannot find module 'dot'] code: 'MODULE_NOT_FOUND' }

fs.js:500
  return binding.readdir(pathModule._makeLong(path));
                 ^
Error: ENOENT, no such file or directory './lib/formful/view'
    at Object.fs.readdirSync (fs.js:500:18)
    at View._loadSync (/Users/travistidwell/Documents/projects/flatiron/node_modules/formful/node_modules/viewful/lib/View.js:123:16)
    at View.load (/Users/travistidwell/Documents/projects/flatiron/node_modules/formful/node_modules/viewful/lib/View.js:86:17)
    at Object.<anonymous> (/Users/travistidwell/Documents/projects/flatiron/node_modules/formful/lib/formful.js:17:6)
    at Module._compile (module.js:449:26)
    at Object.Module._extensions..js (module.js:467:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Module.require (module.js:362:17)
    at require (module.js:378:17)
```

This at least fixes that issue... There are still others that need to be resolved, but I am looking into those as separate issues.
